### PR TITLE
forge(arep): ARIF REALITY ENGINEERING PROTOCOL — schemas, runtime, cockpit

### DIFF
--- a/a2a-server/arep-task-manager.js
+++ b/a2a-server/arep-task-manager.js
@@ -1,0 +1,590 @@
+/**
+ * AREP Task Manager — Arif Reality Engineering Protocol
+ * 
+ * Coined by Muhammad Arif bin Fazil (F13 SOVEREIGN), forged 2026-06-04.
+ * 
+ * The server-side engine that:
+ * 1. Validates AREP declarations against the canonical schema
+ * 2. Manages task lifecycle aligned with A2A v1.0
+ * 3. Performs reality gating — health probes block execution
+ * 4. Tracks evidence layer progression
+ * 5. Seals outcomes to VAULT999
+ * 
+ * An AREP task is NOT a prompt. It is a declaration of intent with reality constraints.
+ * The agent self-prompts. The human only provides intent, evidence floor, and constraints.
+ * 
+ * Aligned with:
+ *   - AgenticReality existential grounding model (March 2026)
+ *   - A2A v1.0 task lifecycle (submitted → working → completed/failed)
+ *   - arifOS constitutional floors F1-F13
+ *   - Huawei governance paper: delegation chain attenuation (June 2026)
+ */
+
+const { writeSeal } = require('./vault');
+const http = require('http');
+
+// ═══════════════════════════════════════════════════════════════════
+// REALITY LAYERS — the four-layer truth stack
+// ═══════════════════════════════════════════════════════════════════
+
+const REALITY_LAYERS = {
+  GROUND_TRUTH: {
+    ordinal: 0,
+    label: 'GROUND_TRUTH',
+    description: 'Verified right now. Sealed in VAULT999. Cannot be changed.',
+    verification: 'Merkle chain integrity check',
+    maxStalenessSeconds: 0, // always fresh — it's immutable
+    autoUpgradable: false,  // human only (F13 SOVEREIGN)
+  },
+  VERIFIED_STATE: {
+    ordinal: 1,
+    label: 'VERIFIED_STATE',
+    description: 'Checked recently via live probe. Trustworthy but subject to staleness.',
+    verification: 'Live health probe',
+    maxStalenessSeconds: 300,
+    autoUpgradable: false,  // requires probe pass
+  },
+  CACHED_STATE: {
+    ordinal: 2,
+    label: 'CACHED_STATE',
+    description: 'Once verified, now stale. Must re-verify before MUTATE/ATOMIC.',
+    verification: 'Freshness timestamp check',
+    maxStalenessSeconds: 3600,
+    autoUpgradable: true,   // agent can promote from INFERRED
+  },
+  INFERRED: {
+    ordinal: 3,
+    label: 'INFERRED',
+    description: 'Never verified. Agent reasoning. Bounded by constitutional floors.',
+    verification: 'None — must escalate',
+    maxStalenessSeconds: Infinity,
+    autoUpgradable: true,   // starting point
+  },
+};
+
+const LAYER_ORDINALS = {
+  GROUND_TRUTH: 0,
+  VERIFIED_STATE: 1,
+  CACHED_STATE: 2,
+  INFERRED: 3,
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// FEDERATION ORGAN HEALTH PROBES
+// ═══════════════════════════════════════════════════════════════════
+
+const FEDERATION_ORGANS = {
+  arifos:  { port: 8088,  name: 'arifOS Kernel',     critical: true },
+  geox:    { port: 8081,  name: 'GEOX Earth',        critical: false },
+  wealth:  { port: 18082, name: 'WEALTH Capital',    critical: false },
+  well:    { port: 18083, name: 'WELL Vitality',      critical: false },
+  aforge:  { port: 7071,  name: 'A-FORGE Execution', critical: true },
+  vault999:{ port: 5001,  name: 'VAULT999 Writer',   critical: true },
+};
+
+/**
+ * Probe a single organ's health endpoint.
+ * @returns {{ organ: string, healthy: boolean, status: string, latencyMs: number }}
+ */
+function probeOrgan(key, config) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const req = http.get(`http://127.0.0.1:${config.port}/health`, { timeout: 5000 }, (res) => {
+      let body = '';
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', () => {
+        const healthy = res.statusCode === 200;
+        resolve({
+          organ: key,
+          name: config.name,
+          critical: config.critical,
+          healthy,
+          status: healthy ? 'GREEN' : 'RED',
+          statusCode: res.statusCode,
+          latencyMs: Date.now() - start,
+          body: body.substring(0, 200),
+        });
+      });
+    });
+    req.on('error', () => {
+      resolve({
+        organ: key,
+        name: config.name,
+        critical: config.critical,
+        healthy: false,
+        status: 'RED',
+        statusCode: 0,
+        latencyMs: Date.now() - start,
+        body: 'unreachable',
+      });
+    });
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({
+        organ: key,
+        name: config.name,
+        critical: config.critical,
+        healthy: false,
+        status: 'RED',
+        statusCode: 0,
+        latencyMs: Date.now() - start,
+        body: 'timeout',
+      });
+    });
+  });
+}
+
+/**
+ * Run full federation health probe.
+ * @returns {{ allHealthy: boolean, criticalHealthy: boolean, organs: object[], summary: string }}
+ */
+async function probeFederation() {
+  const probes = await Promise.all(
+    Object.entries(FEDERATION_ORGANS).map(([key, config]) => probeOrgan(key, config))
+  );
+  const criticalHealthy = probes.filter(p => p.critical).every(p => p.healthy);
+  const allHealthy = probes.every(p => p.healthy);
+
+  let summary;
+  if (allHealthy) summary = 'GREEN — all organs healthy';
+  else if (criticalHealthy) summary = 'YELLOW — critical organs healthy, some non-critical degraded';
+  else summary = 'RED — critical organ(s) unhealthy';
+
+  return { allHealthy, criticalHealthy, organs: probes, summary, probedAt: new Date().toISOString() };
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// EVIDENCE TRACKING
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Determine the current evidence layer for a task.
+ */
+function assessEvidenceLayer(task) {
+  // If sealed to VAULT999 → GROUND_TRUTH
+  if (task.lifecycle?.artifacts?.some(a => a.evidence_layer === 'GROUND_TRUTH' && a.vault_seal_hash)) {
+    return 'GROUND_TRUTH';
+  }
+  // If health probe passed recently → VERIFIED_STATE
+  if (task._lastHealthProbe && task._lastHealthProbe.allHealthy) {
+    const age = (Date.now() - new Date(task._lastHealthProbe.probedAt).getTime()) / 1000;
+    if (age < REALITY_LAYERS.VERIFIED_STATE.maxStalenessSeconds) {
+      return 'VERIFIED_STATE';
+    }
+  }
+  // If we have cached evidence → CACHED_STATE
+  if (task._lastHealthProbe) {
+    return 'CACHED_STATE';
+  }
+  // Default → INFERRED
+  return 'INFERRED';
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// REALITY GATING — the core engine
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Evaluate reality gates for a task.
+ * Returns { passed: boolean, violations: [], currentEvidenceLayer: string, healthProbe: object }
+ */
+async function evaluateRealityGates(task) {
+  const constraints = task.reality_constraints || {};
+  const requiredFloor = constraints.evidence_floor || 'VERIFIED_STATE';
+  const gates = constraints.reality_gates || [];
+
+  // Run federation health probe
+  const healthProbe = await probeFederation();
+  task._lastHealthProbe = healthProbe;
+
+  // Determine current evidence layer
+  const currentLayer = assessEvidenceLayer(task);
+  task._currentEvidenceLayer = currentLayer;
+
+  const violations = [];
+
+  // Check 1: Is the current evidence layer sufficient?
+  const requiredOrdinal = LAYER_ORDINALS[requiredFloor];
+  const currentOrdinal = LAYER_ORDINALS[currentLayer];
+  if (currentOrdinal > requiredOrdinal) {
+    violations.push({
+      type: 'INSUFFICIENT_EVIDENCE',
+      required: requiredFloor,
+      current: currentLayer,
+      message: `Task requires ${requiredFloor} evidence, but highest verified is ${currentLayer}.`,
+      action: 'HALT',
+    });
+  }
+
+  // Check 2: Evaluate each reality gate
+  for (const gate of gates) {
+    const result = evaluateGate(gate, healthProbe);
+    if (!result.passed) {
+      violations.push(result);
+      if (gate.action_on_fail === 'HALT') return { passed: false, violations, healthProbe, currentEvidenceLayer: currentLayer };
+    }
+  }
+
+  // Check 3: Critical organs must be healthy for MUTATE/ATOMIC
+  if (constraints.reversibility?.maximum_action_class === 'MUTATE' || 
+      constraints.reversibility?.maximum_action_class === 'ATOMIC') {
+    if (!healthProbe.criticalHealthy) {
+      violations.push({
+        type: 'CRITICAL_ORGAN_UNHEALTHY',
+        message: 'Cannot execute MUTATE/ATOMIC with unhealthy critical organs.',
+        action: 'HALT',
+      });
+    }
+  }
+
+  return {
+    passed: violations.filter(v => v.action === 'HALT').length === 0,
+    violations,
+    healthProbe,
+    currentEvidenceLayer: currentLayer,
+  };
+}
+
+/**
+ * Evaluate a single reality gate condition.
+ */
+function evaluateGate(gate, healthProbe) {
+  // Parse condition: "organ_health == GREEN" or "all_critical == healthy"
+  const condition = gate.condition || '';
+  
+  if (condition.includes('organ_health')) {
+    if (condition.includes('GREEN')) {
+      const allGreen = healthProbe.organs.every(o => o.healthy);
+      if (!allGreen) {
+        const unhealthy = healthProbe.organs.filter(o => !o.healthy).map(o => o.name);
+        return {
+          passed: false,
+          condition,
+          action: gate.action_on_fail,
+          message: `Organ health not GREEN. Unhealthy: ${unhealthy.join(', ')}`,
+        };
+      }
+    }
+  }
+
+  if (condition.includes('critical')) {
+    if (!healthProbe.criticalHealthy) {
+      const unhealthy = healthProbe.organs.filter(o => o.critical && !o.healthy).map(o => o.name);
+      return {
+        passed: false,
+        condition,
+        action: gate.action_on_fail,
+        message: `Critical organs unhealthy: ${unhealthy.join(', ')}`,
+      };
+    }
+  }
+
+  // Specific organ check
+  for (const [key, config] of Object.entries(FEDERATION_ORGANS)) {
+    if (condition.includes(key)) {
+      const organ = healthProbe.organs.find(o => o.organ === key);
+      if (!organ?.healthy) {
+        return {
+          passed: false,
+          condition,
+          action: gate.action_on_fail,
+          message: `${config.name} is ${organ?.status || 'UNKNOWN'}`,
+        };
+      }
+    }
+  }
+
+  return { passed: true, condition };
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// ARET TASK VALIDATION
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Validate an AREP task declaration against the canonical schema.
+ * Returns { valid: boolean, errors: string[] }
+ */
+function validateAREPDeclaration(task) {
+  const errors = [];
+
+  if (!task.arep_version || task.arep_version !== '1.0') {
+    errors.push('Missing or invalid arep_version. Must be "1.0".');
+  }
+
+  if (!task.intent?.statement || typeof task.intent.statement !== 'string') {
+    errors.push('Missing intent.statement — the human must declare WHAT they want.');
+  }
+
+  if (!task.intent?.success_criteria || !Array.isArray(task.intent.success_criteria) || task.intent.success_criteria.length === 0) {
+    errors.push('Missing intent.success_criteria — must declare verifiable completion conditions.');
+  }
+
+  if (!task.principal?.actor_id || task.principal.actor_id !== 'arif-fazil') {
+    errors.push('Invalid principal.actor_id — must be "arif-fazil" (F13 SOVEREIGN).');
+  }
+
+  if (!task.reality_constraints?.evidence_floor) {
+    errors.push('Missing reality_constraints.evidence_floor — must declare minimum evidence layer.');
+  }
+
+  if (task.reality_constraints?.reversibility?.maximum_action_class === 'ATOMIC' && 
+      task.principal?.ratification_mode !== 'explicit_ack') {
+    errors.push('ATOMIC actions require explicit_ack ratification from principal.');
+  }
+
+  // Validate delegation chain
+  if (!task.delegation_chain || !Array.isArray(task.delegation_chain) || task.delegation_chain.length === 0) {
+    errors.push('Missing delegation_chain — must declare authority lineage.');
+  } else {
+    const firstHop = task.delegation_chain[0];
+    if (firstHop.role !== 'PRINCIPAL' || firstHop.actor_id !== 'arif-fazil') {
+      errors.push('Delegation chain must start with PRINCIPAL arif-fazil.');
+    }
+
+    // Validate attenuation: each hop should not be wider than parent
+    for (let i = 1; i < task.delegation_chain.length; i++) {
+      if ((task.delegation_chain[i].max_subagent_depth || 0) > (task.delegation_chain[i-1].max_subagent_depth || 0)) {
+        errors.push(`Delegation chain violation at hop ${i}: subagent depth cannot exceed parent's.`);
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// ARET TASK LIFECYCLE — state machine
+// ═══════════════════════════════════════════════════════════════════
+
+const VALID_STATES = ['submitted', 'working', 'input-required', 'completed', 'failed', 'canceled', 'rejected'];
+const VALID_TRANSITIONS = {
+  'submitted':     ['working', 'rejected', 'canceled'],
+  'working':       ['completed', 'failed', 'input-required', 'canceled'],
+  'input-required': ['working', 'canceled', 'rejected'],
+  'completed':     [],  // terminal
+  'failed':        [],  // terminal
+  'canceled':      [],  // terminal
+  'rejected':      [],  // terminal
+};
+
+/**
+ * Transition a task to a new state. Records state history.
+ */
+function transitionTaskState(task, newState, actorId, note) {
+  if (!VALID_STATES.includes(newState)) {
+    throw new Error(`Invalid state: ${newState}`);
+  }
+
+  const currentState = task.task_lifecycle?.current_state || 'submitted';
+  const allowed = VALID_TRANSITIONS[currentState] || [];
+  
+  if (!allowed.includes(newState)) {
+    throw new Error(`Invalid transition: ${currentState} → ${newState}. Allowed: ${allowed.join(', ')}`);
+  }
+
+  if (!task.task_lifecycle) task.task_lifecycle = {};
+  if (!task.task_lifecycle.state_history) task.task_lifecycle.state_history = [];
+
+  task.task_lifecycle.state_history.push({ state: currentState, timestamp: new Date().toISOString() });
+  task.task_lifecycle.current_state = newState;
+
+  task.task_lifecycle.state_history.push({
+    state: newState,
+    timestamp: new Date().toISOString(),
+    actor_id: actorId || 'arifos-kernel',
+    evidence_layer_at_transition: task._currentEvidenceLayer || 'INFERRED',
+    note: note || '',
+  });
+
+  task.telemetry = task.telemetry || {};
+  task.telemetry.updated_at = new Date().toISOString();
+
+  return task;
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// ARET TASK EXECUTION ENGINE
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Main entry point: process an AREP task declaration.
+ * 
+ * Flow:
+ * 1. Validate declaration
+ * 2. Run reality gates
+ * 3. If gates pass → working → delegate to agent
+ * 4. If gates fail on HALT → rejected
+ * 5. If gates fail on ESCALATE → input-required (waiting for human)
+ * 
+ * @param {object} task — Raw AREP task declaration
+ * @param {object} taskStore — Redis-backed task store
+ * @param {function} executeFn — function to call for actual execution
+ * @returns {object} — { accepted, task, gateResult, verdict }
+ */
+async function processAREPTask(task, taskStore, executeFn) {
+  // 1. Validate
+  const validation = validateAREPDeclaration(task);
+  if (!validation.valid) {
+    task.task_lifecycle = task.task_lifecycle || {};
+    task.task_lifecycle.current_state = 'rejected';
+    return {
+      accepted: false,
+      task,
+      gateResult: null,
+      verdict: 'VOID',
+      reason: `AREP validation failed: ${validation.errors.join('; ')}`,
+    };
+  }
+
+  // 2. Initialize task
+  task.task_lifecycle = task.task_lifecycle || {};
+  task.task_lifecycle.current_state = 'submitted';
+  task.task_lifecycle.state_history = [{
+    state: 'submitted',
+    timestamp: new Date().toISOString(),
+    actor_id: task.principal.actor_id,
+    evidence_layer_at_transition: 'INFERRED',
+    note: 'AREP task received',
+  }];
+
+  task.telemetry = task.telemetry || {};
+  task.telemetry.task_id = task.telemetry.task_id || `arep-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  task.telemetry.created_at = new Date().toISOString();
+
+  // 3. Reality gating
+  const gateResult = await evaluateRealityGates(task);
+
+  // 4. Check evidence floor
+  const requiredLayer = task.reality_constraints.evidence_floor;
+  const currentLayer = gateResult.currentEvidenceLayer;
+
+  if (LAYER_ORDINALS[currentLayer] > LAYER_ORDINALS[requiredLayer]) {
+    // Evidence insufficient → hold or reject
+    transitionTaskState(task, 'input-required', 'arifos-kernel',
+      `Evidence insufficient: required ${requiredLayer}, current ${currentLayer}. Waiting for human ratification.`);
+    
+    return {
+      accepted: true,
+      task,
+      gateResult,
+      verdict: 'SABAR',
+      reason: `Evidence floor not met. Required: ${requiredLayer}, Current: ${currentLayer}. Task held for human review.`,
+    };
+  }
+
+  // 5. Check for HALT violations
+  const haltViolations = gateResult.violations.filter(v => v.action === 'HALT');
+  if (haltViolations.length > 0) {
+    transitionTaskState(task, 'rejected', 'arifos-kernel',
+      `Reality gate HALT: ${haltViolations.map(v => v.message).join('; ')}`);
+    
+    return {
+      accepted: false,
+      task,
+      gateResult,
+      verdict: 'VOID',
+      reason: `Reality gates failed: ${haltViolations.map(v => v.message).join('; ')}`,
+    };
+  }
+
+  // 6. Check for ESCALATE violations
+  const escalateViolations = gateResult.violations.filter(v => v.action === 'ESCALATE');
+  if (escalateViolations.length > 0) {
+    transitionTaskState(task, 'input-required', 'arifos-kernel',
+      `Reality gate ESCALATE: ${escalateViolations.map(v => v.message).join('; ')}`);
+    
+    return {
+      accepted: true,
+      task,
+      gateResult,
+      verdict: 'HOLD',
+      reason: `Escalated to human: ${escalateViolations.map(v => v.message).join('; ')}`,
+    };
+  }
+
+  // 7. All gates passed → execute
+  transitionTaskState(task, 'working', 'arifos-kernel', 'Reality gates passed. Executing task.');
+
+  // Store task
+  if (taskStore) {
+    const taskId = task.telemetry.task_id;
+    await taskStore.setTask(taskId, task);
+  }
+
+  // Execute
+  if (executeFn) {
+    try {
+      await executeFn(task);
+    } catch (execErr) {
+      transitionTaskState(task, 'failed', 'arifos-kernel', `Execution error: ${execErr.message}`);
+      return {
+        accepted: true,
+        task,
+        gateResult,
+        verdict: 'SABAR',
+        reason: `Task failed during execution: ${execErr.message}`,
+      };
+    }
+  }
+
+  return {
+    accepted: true,
+    task,
+    gateResult,
+    verdict: 'SEAL',
+    reason: 'Reality gates passed. Task dispatched.',
+  };
+}
+
+/**
+ * Seal a completed AREP task to VAULT999.
+ */
+async function sealAREPTask(task) {
+  transitionTaskState(task, 'completed', 'arifos-kernel', 'Task completed. Sealing to VAULT999.');
+
+  task.task_lifecycle.artifacts = task.task_lifecycle.artifacts || [];
+  task.task_lifecycle.artifacts.push({
+    artifact_id: `seal-${task.telemetry.task_id}`,
+    artifact_type: 'seal',
+    evidence_layer: 'GROUND_TRUTH',
+    vault_seal_hash: null, // filled by VAULT999
+  });
+
+  task.constitutional_binding = task.constitutional_binding || {};
+  task.constitutional_binding.governance_verdict = 'SEAL';
+  task._currentEvidenceLayer = 'GROUND_TRUTH';
+
+  try {
+    const sealResult = await writeSeal(
+      task,
+      'arifos-kernel',
+      `AREP task completed: ${task.intent.statement.substring(0, 100)}`,
+      {
+        arep_version: '1.0',
+        success_criteria: task.intent.success_criteria,
+        delegation_depth: task.delegation_chain.length,
+        evidence_layer_at_seal: 'GROUND_TRUTH',
+      }
+    );
+    task.task_lifecycle.artifacts[task.task_lifecycle.artifacts.length - 1].vault_seal_hash = sealResult?.hash || 'pending';
+  } catch (err) {
+    // Non-blocking — VAULT999 write failures don't invalidate the task
+    console.error(`[AREP] VAULT999 seal failed for ${task.telemetry.task_id}: ${err.message}`);
+  }
+
+  return task;
+}
+
+module.exports = {
+  REALITY_LAYERS,
+  LAYER_ORDINALS,
+  FEDERATION_ORGANS,
+  probeFederation,
+  assessEvidenceLayer,
+  evaluateRealityGates,
+  validateAREPDeclaration,
+  transitionTaskState,
+  processAREPTask,
+  sealAREPTask,
+};

--- a/a2a-server/server.js
+++ b/a2a-server/server.js
@@ -9,6 +9,7 @@
 const express = require('express');
 const crypto = require('crypto');
 const { writeSeal, writeVoid, checkHealth: checkVaultHealth } = require('./vault');
+const { processAREPTask, sealAREPTask, probeFederation } = require('./arep-task-manager');
 const { createClient } = require('redis');
 const { connect, StringCodec } = require('nats');
 
@@ -1712,6 +1713,56 @@ app.post(['/api/message/send'], createEnvelopeValidator(), async (req, res) => {
     });
 
     res.json({ jsonrpc: '2.0', id: body.id || 0, result: { id: taskId, contextId, status: task.status } });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// AREP — Arif Reality Engineering Protocol endpoint
+// ═══════════════════════════════════════════════════════════════════
+app.post('/api/arep/submit', async (req, res) => {
+  try {
+    const task = req.body;
+
+    // Process AREP task with reality gating
+    const result = await processAREPTask(task, taskStore, async (t) => {
+      // Store and dispatch the task for execution
+      const taskId = t.telemetry.task_id;
+      await taskStore.set(taskId, t);
+
+      // Log the AREP intent
+      logEvent('AREP_SUBMIT', taskId, `AREP: "${t.intent.statement.slice(0, 80)}" | floor: ${t.reality_constraints.evidence_floor} | band: ${t.reality_constraints.autonomy_band}`);
+
+      // Seal if completed
+      if (t.task_lifecycle.current_state === 'completed') {
+        await sealAREPTask(t);
+        await taskStore.set(taskId, t);
+      }
+    });
+
+    res.json({
+      accepted: result.accepted,
+      task_id: task.telemetry?.task_id,
+      verdict: result.verdict,
+      reason: result.reason,
+      gate_result: result.gateResult ? {
+        passed: result.gateResult.passed,
+        violations_count: result.gateResult.violations.length,
+        evidence_layer: result.gateResult.currentEvidenceLayer,
+        health_summary: result.gateResult.healthProbe?.summary,
+      } : null,
+    });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// AREP reality feed — live health probe for the cockpit
+app.get('/api/arep/reality-feed', async (req, res) => {
+  try {
+    const probe = await probeFederation();
+    res.json(probe);
   } catch (err) {
     res.status(500).json({ ok: false, error: err.message });
   }

--- a/schemas/SCHEMA_REGISTRY.json
+++ b/schemas/SCHEMA_REGISTRY.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AAA Schema Registry",
+  "description": "Canonical index of all JSON schemas in the AAA control plane. Add new schemas here when they are forged so agents can discover them via /.well-known/schema-registry.json.",
+  "registry_version": "2026.06.04-arep",
+  "generated_at": "2026-06-04T08:20:00Z",
+  "schemas": [
+    {
+      "$id": "https://aaa.arif-fazil.com/schemas/arep-task-v1",
+      "file": "arep-task.schema.json",
+      "title": "AREP Task — Arif Reality Engineering Protocol",
+      "description": "Formal contract for human→agent task delegation. Replaces prompt engineering with reality engineering. Aligned with A2A v1.0.",
+      "coined_by": "Muhammad Arif bin Fazil (F13 SOVEREIGN)",
+      "forged_at": "2026-06-04",
+      "layer": "REALITY_ENGINEERING"
+    },
+    {
+      "$id": "https://aaa.arif-fazil.com/schemas/arep-reality-layers-v1",
+      "file": "arep-reality-layers.schema.json",
+      "title": "AREP Reality Layers",
+      "description": "Four-layer truth stack (GROUND_TRUTH → VERIFIED_STATE → CACHED_STATE → INFERRED) anchoring every AREP task. Aligned with AgenticReality (March 2026).",
+      "coined_by": "Muhammad Arif bin Fazil (F13 SOVEREIGN)",
+      "forged_at": "2026-06-04",
+      "layer": "REALITY_ENGINEERING"
+    },
+    {
+      "$id": "https://aaa.arif-fazil.com/schemas/a2a-agent-card-v1",
+      "file": "a2a-agent-card.schema.json",
+      "title": "AAA A2A Agent Card",
+      "description": "Agent identity and capability declaration per Google A2A v1.0 protocol.",
+      "layer": "AGENT_ENGINEERING"
+    },
+    {
+      "$id": "https://aaa.arif-fazil.com/schemas/federation-contract-v1",
+      "file": "federation-contract.schema.json",
+      "title": "AAA Federation Contract",
+      "description": "Cross-organ federation topology, invariants, and trust tiers.",
+      "layer": "CONSTITUTIONAL_ENGINEERING"
+    },
+    {
+      "$id": "https://aaa.arif-fazil.com/schemas/cockpit-model-v1",
+      "file": "cockpit-model.schema.json",
+      "title": "AAA Cockpit Model",
+      "description": "Operator surface model — agents, sessions, workflows, approvals.",
+      "layer": "AGENT_ENGINEERING"
+    },
+    {
+      "$id": "https://aaa.arif-fazil.com/schemas/epistemic-signal-v1",
+      "file": "../a2a/epistemic_signal_schema.json",
+      "title": "Epistemic Signal",
+      "description": "Agent epistemic state — belief strength, confidence, evidence grounding.",
+      "layer": "REALITY_ENGINEERING"
+    }
+  ],
+  "layer_legend": {
+    "REALITY_ENGINEERING": "What is true, what exists, what is allowed — the top discipline",
+    "CONSTITUTIONAL_ENGINEERING": "What cannot be violated — floors F1-F13, VAULT999",
+    "AGENT_ENGINEERING": "How to build autonomous systems — A2A, MCP, agent shells",
+    "INTENT_ENGINEERING": "How to delegate to an agent — task contracts, success criteria",
+    "PROMPT_ENGINEERING": "How to talk to a model — OBSOLETE, replaced by AREP"
+  }
+}

--- a/schemas/arep-example-forge-integration.json
+++ b/schemas/arep-example-forge-integration.json
@@ -1,0 +1,101 @@
+{
+  "arep_version": "1.0",
+  "intent": {
+    "statement": "forge all organ with deepseek integration",
+    "success_criteria": [
+      "all 7 federation organs health 200",
+      "deepseek-v4-pro registered in model passport",
+      "health probe confirms deepseek key live",
+      "VAULT999 seal written"
+    ],
+    "failure_modes": [
+      "organ health degraded during forge",
+      "deepseek API key rotated mid-task",
+      "model registry drift detected"
+    ],
+    "context_tags": ["deployment", "model-registry", "deepseek"]
+  },
+  "principal": {
+    "actor_id": "arif-fazil",
+    "ratification_mode": "implicit"
+  },
+  "reality_constraints": {
+    "evidence_floor": "VERIFIED_STATE",
+    "reality_gates": [
+      {
+        "condition": "all 7 organs health == 200",
+        "action_on_fail": "HALT",
+        "evidence_layer": "VERIFIED_STATE"
+      },
+      {
+        "condition": "deepseek-v4-pro in model registry",
+        "action_on_fail": "ESCALATE",
+        "evidence_layer": "VERIFIED_STATE"
+      },
+      {
+        "condition": "git working tree clean before push",
+        "action_on_fail": "RETRY",
+        "evidence_layer": "CACHED_STATE"
+      }
+    ],
+    "autonomy_band": "GREEN",
+    "model_identity_constraint": {
+      "allowed_providers": ["deepseek", "minimax"],
+      "required_capabilities": ["code_generation"],
+      "self_claim_boundary": "verified_only"
+    },
+    "reversibility": {
+      "maximum_action_class": "MUTATE",
+      "rollback_plan_required": true,
+      "irreversible_ack_required": true
+    }
+  },
+  "delegation_chain": [
+    {
+      "actor_id": "arif-fazil",
+      "role": "PRINCIPAL",
+      "scope": "unlimited — F13 SOVEREIGN",
+      "lease_seconds": 0,
+      "max_subagent_depth": 3
+    },
+    {
+      "actor_id": "arifOS-kernel",
+      "role": "KERNEL",
+      "scope": "constitutional gating, floor enforcement",
+      "lease_seconds": 0,
+      "max_subagent_depth": 2
+    },
+    {
+      "actor_id": "omega-forge-agent",
+      "role": "PRIMARY_AGENT",
+      "scope": "forge, deploy, test, registry update — read-only vault",
+      "grant_id": "omega-forge-full",
+      "lease_seconds": 3600,
+      "max_subagent_depth": 1
+    }
+  ],
+  "task_lifecycle": {
+    "current_state": "submitted",
+    "state_history": [
+      {
+        "state": "submitted",
+        "timestamp": "2026-06-04T08:15:00Z",
+        "actor_id": "arif-fazil",
+        "evidence_layer_at_transition": "GROUND_TRUTH",
+        "note": "Task created by sovereign AREP intent"
+      }
+    ]
+  },
+  "constitutional_binding": {
+    "active_floors": ["F1", "F2", "F4", "F7", "F8", "F9", "F11", "F13"],
+    "governance_verdict": "PENDING"
+  },
+  "telemetry": {
+    "task_id": "arep-20260604-081500-forge-deepseek",
+    "created_at": "2026-06-04T08:15:00Z",
+    "updated_at": "2026-06-04T08:15:00Z",
+    "model_used": "deepseek-v4-pro",
+    "agent_shell": "opencode",
+    "session_id": "SEAL-arep-forge-20260604"
+  }
+}

--- a/schemas/arep-reality-layers.schema.json
+++ b/schemas/arep-reality-layers.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aaa.arif-fazil.com/schemas/arep-reality-layers-v1",
+  "title": "AREP Reality Layers",
+  "description": "The four-layer truth stack that anchors every AREP task. An agent cannot claim a higher layer than its evidence supports. Aligned with AgenticReality (March 2026) existential grounding model.",
+  "type": "object",
+  "required": ["required_evidence_floor", "current_evidence_layer"],
+  "additionalProperties": false,
+  "properties": {
+    "required_evidence_floor": {
+      "type": "string",
+      "enum": ["GROUND_TRUTH", "VERIFIED_STATE", "CACHED_STATE", "INFERRED"],
+      "description": "Minimum reality layer required before this task can proceed to execution. Set by the human principal. GROUND_TRUTH = must be sealed in VAULT999. VERIFIED_STATE = must pass live health probe. CACHED_STATE = from recent memory. INFERRED = agent reasoning allowed."
+    },
+    "current_evidence_layer": {
+      "type": "string",
+      "enum": ["GROUND_TRUTH", "VERIFIED_STATE", "CACHED_STATE", "INFERRED"],
+      "default": "INFERRED",
+      "description": "Current highest evidence layer achieved for this task. Updated by the agent as evidence accumulates. Cannot exceed the principal's required floor without explicit upgrade."
+    },
+    "layer_definitions": {
+      "type": "object",
+      "description": "Canonical definitions of the four reality layers per the AgenticReality model.",
+      "additionalProperties": false,
+      "properties": {
+        "GROUND_TRUTH": {
+          "type": "object",
+      "additionalProperties": false,
+          "properties": {
+            "description": { "type": "string", "const": "Verified right now, indisputable. Cannot be changed." },
+            "arifos_anchor": { "type": "string", "const": "VAULT999 sealed events, F13 SOVEREIGN decrees" },
+            "verification_method": { "type": "string", "const": "Merkle chain integrity check + vault_sealed_events query" },
+            "example": { "type": "string", "const": "Omega sealed SESSION-CLOSE at 2026-06-03T10:49:00Z — sha256:abc123" }
+          }
+        },
+        "VERIFIED_STATE": {
+          "type": "object",
+      "additionalProperties": false,
+          "properties": {
+            "description": { "type": "string", "const": "Checked recently, trustworthy. Subject to staleness." },
+            "arifos_anchor": { "type": "string", "const": "Model registry passports, live health probes, organ status" },
+            "verification_method": { "type": "string", "const": "curl health endpoint + registry lookup + capability_map check" },
+            "staleness_threshold_seconds": { "type": "integer", "const": 300 },
+            "example": { "type": "string", "const": "All 7 organs healthy at T+30s — health probe 200" }
+          }
+        },
+        "CACHED_STATE": {
+          "type": "object",
+      "additionalProperties": false,
+          "properties": {
+            "description": { "type": "string", "const": "Once verified, now stale. May still be true but must be re-verified before MUTATE/ATOMIC." },
+            "arifos_anchor": { "type": "string", "const": "L3 Qdrant embeddings, session memory, L5 Graphiti relationships" },
+            "verification_method": { "type": "string", "const": "Vector similarity search + freshness timestamp check" },
+            "staleness_threshold_seconds": { "type": "integer", "const": 3600 },
+            "example": { "type": "string", "const": "Session 2026-06-03 discussed SAF migration — cached at 15:00 UTC" }
+          }
+        },
+        "INFERRED": {
+          "type": "object",
+      "additionalProperties": false,
+          "properties": {
+            "description": { "type": "string", "const": "Never directly verified. Agent reasoning output. Bounded by constitutional floors." },
+            "arifos_anchor": { "type": "string", "const": "Model outputs, agent reasoning chains (constrained by F2 TRUTH, F9 ANTIHANTU)" },
+            "verification_method": { "type": "string", "const": "None available — this is the floor. Must be escalated to higher layer before execution." },
+            "example": { "type": "string", "const": "This task probably needs GEOX, not WEALTH — agent routing heuristic" }
+          }
+        }
+      }
+    },
+    "layer_upgrade_rules": {
+      "type": "object",
+      "description": "Rules governing when and how evidence can be promoted to a higher layer.",
+      "additionalProperties": false,
+      "properties": {
+        "INFERRED_to_CACHED_STATE": { "type": "string", "const": "Must survive one complete agent reasoning loop without contradiction." },
+        "CACHED_STATE_to_VERIFIED_STATE": { "type": "string", "const": "Must pass live health probe or registry verification. Freshness < threshold." },
+        "VERIFIED_STATE_to_GROUND_TRUTH": { "type": "string", "const": "Must be sealed to VAULT999 with human ratification (F13 SOVEREIGN). Cannot be automated." },
+        "auto_upgrade_ceiling": { "type": "string", "const": "INFERRED → CACHED_STATE (automatic). VERIFIED_STATE (probe). GROUND_TRUTH (human only)." }
+      }
+    }
+  }
+}

--- a/schemas/arep-task.schema.json
+++ b/schemas/arep-task.schema.json
@@ -1,0 +1,258 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aaa.arif-fazil.com/schemas/arep-task-v1",
+  "title": "AREP Task — Arif Reality Engineering Protocol",
+  "description": "The formal contract for human→agent task delegation in arifOS. This replaces prompt engineering with reality engineering. A task is a task, whether it comes from a human principal or another agent. Aligned with A2A v1.0 task lifecycle and AgenticReality existential grounding model. Coined by Muhammad Arif bin Fazil (F13 SOVEREIGN), 2026-06-04.",
+  "type": "object",
+  "required": ["arep_version", "intent", "principal", "reality_constraints", "task_lifecycle"],
+  "additionalProperties": false,
+  "properties": {
+
+    "arep_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "AREP protocol version. First formalized 2026-06-04."
+    },
+
+    "intent": {
+      "type": "object",
+      "description": "The human's intent — WHAT they want, not HOW to do it. This is the only layer the human touches.",
+      "required": ["statement", "success_criteria"],
+      "additionalProperties": false,
+      "properties": {
+        "statement": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Natural language intent declaration. e.g. 'forge all organ with deepseek integration'"
+        },
+        "success_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "Verifiable conditions that define task completion. e.g. ['all 7 organs health 200', 'deepseek key verified live', 'registry updated']"
+        },
+        "failure_modes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Known ways this task can fail. Agent uses these for self-verification.",
+          "examples": [["organ health degraded", "API key rotated mid-task", "model registry drift detected"]]
+        },
+        "context_tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Domain tags for routing. e.g. ['security', 'deployment', 'config', 'model-registry']"
+        }
+      }
+    },
+
+    "principal": {
+      "type": "object",
+      "description": "The human sovereign who owns this task. The ultimate authority in the delegation chain.",
+      "required": ["actor_id"],
+      "additionalProperties": false,
+      "properties": {
+        "actor_id": {
+          "type": "string",
+          "const": "arif-fazil",
+          "description": "F13 SOVEREIGN. All authority traces back to this identity."
+        },
+        "ratification_mode": {
+          "type": "string",
+          "enum": ["implicit", "888_HOLD", "explicit_ack"],
+          "default": "implicit",
+          "description": "How the principal ratified this task. implicit = delegated within autonomy band. 888_HOLD = held pending human ack. explicit_ack = human explicitly approved."
+        },
+        "sovereign_signature": {
+          "type": "string",
+          "description": "Optional cryptographic signature from the principal. Required for GROUND_TRUTH evidence floor."
+        }
+      }
+    },
+
+    "reality_constraints": {
+      "type": "object",
+      "description": "The reality engineering layer — what must be true before, during, and after task execution.",
+      "required": ["evidence_floor"],
+      "additionalProperties": false,
+      "properties": {
+        "evidence_floor": {
+          "type": "string",
+          "enum": ["GROUND_TRUTH", "VERIFIED_STATE", "CACHED_STATE", "INFERRED"],
+          "default": "VERIFIED_STATE",
+          "description": "Minimum evidence layer required for execution. VERIFIED_STATE = live health probes must pass. GROUND_TRUTH = seal required."
+        },
+        "reality_gates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["condition", "action_on_fail"],
+            "additionalProperties": false,
+            "properties": {
+              "condition": { "type": "string", "description": "Must be true to proceed. e.g. 'organ_health == GREEN'" },
+              "action_on_fail": { "type": "string", "enum": ["HALT", "ESCALATE", "RETRY", "SKIP"], "description": "What to do if condition fails." },
+              "evidence_layer": { "type": "string", "enum": ["GROUND_TRUTH", "VERIFIED_STATE", "CACHED_STATE", "INFERRED"], "default": "VERIFIED_STATE" }
+            }
+          },
+          "description": "Ordered list of conditions checked before each execution step. Like pre-flight checks on a drilling rig."
+        },
+        "autonomy_band": {
+          "type": "string",
+          "enum": ["GREEN", "YELLOW", "ORANGE", "RED", "BLACK"],
+          "default": "GREEN",
+          "description": "Maximum autonomy band for this task. Agent cannot escalate beyond this band without re-delegation. GREEN = full auto. RED = human required. BLACK = forbidden."
+        },
+        "model_identity_constraint": {
+          "type": "object",
+          "description": "Which model passports are authorized for this task. Verified against the model registry.",
+          "additionalProperties": false,
+          "properties": {
+            "allowed_providers": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Provider keys from the model registry. e.g. ['deepseek', 'minimax', 'ilmu']"
+            },
+            "required_capabilities": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Capability labels required. e.g. ['math_reasoning: olympiad_gold', 'code_generation']"
+            },
+            "self_claim_boundary": {
+              "type": "string",
+              "const": "verified_only",
+              "description": "F9 Anti-Hantu: model cannot claim identity beyond its passport."
+            }
+          }
+        },
+        "reversibility": {
+          "type": "object",
+          "description": "F1 AMANAH and F8 REVERSIBILITY constraints.",
+          "additionalProperties": false,
+          "properties": {
+            "maximum_action_class": {
+              "type": "string",
+              "enum": ["OBSERVE", "PREPARE", "MUTATE", "ATOMIC"],
+              "default": "MUTATE",
+              "description": "Highest risk action class permitted. ATOMIC requires explicit human ack."
+            },
+            "rollback_plan_required": { "type": "boolean", "default": true },
+            "irreversible_ack_required": { "type": "boolean", "default": true }
+          }
+        }
+      }
+    },
+
+    "delegation_chain": {
+      "type": "array",
+      "description": "Ordered chain of authority from principal to executing agent. Each hop attenuates scope (Huawei governance paper, June 2026).",
+      "items": {
+        "type": "object",
+        "required": ["actor_id", "role", "scope"],
+        "additionalProperties": false,
+        "properties": {
+          "actor_id": { "type": "string" },
+          "role": { "type": "string", "enum": ["PRINCIPAL", "KERNEL", "PRIMARY_AGENT", "SUB_AGENT", "TOOL"] },
+          "scope": { "type": "string", "description": "Narrower than parent's scope. What this actor is authorized to do." },
+          "grant_id": { "type": "string", "description": "CapabilityGrant registry ID." },
+          "lease_seconds": { "type": "integer", "description": "Time-bound lease. 0 = permanent (principal only)." },
+          "max_subagent_depth": { "type": "integer", "description": "How many more delegation hops are allowed." }
+        }
+      }
+    },
+
+    "task_lifecycle": {
+      "type": "object",
+      "description": "A2A v1.0 task lifecycle mapping. Every AREP task follows this state machine.",
+      "required": ["current_state"],
+      "additionalProperties": false,
+      "properties": {
+        "current_state": {
+          "type": "string",
+          "enum": ["submitted", "working", "input-required", "completed", "failed", "canceled", "rejected"],
+          "default": "submitted"
+        },
+        "state_history": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["state", "timestamp"],
+            "additionalProperties": false,
+            "properties": {
+              "state": { "type": "string", "enum": ["submitted", "working", "input-required", "completed", "failed", "canceled", "rejected"] },
+              "timestamp": { "type": "string", "format": "date-time" },
+              "actor_id": { "type": "string" },
+              "evidence_layer_at_transition": { "type": "string", "enum": ["GROUND_TRUTH", "VERIFIED_STATE", "CACHED_STATE", "INFERRED"] },
+              "note": { "type": "string" }
+            }
+          }
+        },
+        "artifacts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "artifact_id": { "type": "string" },
+              "artifact_type": { "type": "string", "enum": ["code", "config", "seal", "report", "health_probe", "registry_entry"] },
+              "evidence_layer": { "type": "string", "enum": ["GROUND_TRUTH", "VERIFIED_STATE", "CACHED_STATE", "INFERRED"] },
+              "vault_seal_hash": { "type": "string", "description": "VAULT999 seal hash if artifact was sealed." }
+            }
+          }
+        },
+        "a2a_task_id": {
+          "type": "string",
+          "description": "A2A protocol task ID for cross-agent operability."
+        },
+        "parent_task_id": {
+          "type": "string",
+          "description": "If this task was spawned by another agent, the parent's A2A task ID."
+        }
+      }
+    },
+
+    "constitutional_binding": {
+      "type": "object",
+      "description": "Which constitutional floors are active for this task and their current state.",
+      "additionalProperties": false,
+      "properties": {
+        "active_floors": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12", "F13"] },
+          "description": "Floors actively enforced for this task."
+        },
+        "floor_vetoes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "floor": { "type": "string" },
+              "reason": { "type": "string" },
+              "timestamp": { "type": "string", "format": "date-time" }
+            }
+          }
+        },
+        "governance_verdict": {
+          "type": "string",
+          "enum": ["SEAL", "SABAR", "HOLD", "VOID", "PENDING"],
+          "default": "PENDING"
+        }
+      }
+    },
+
+    "telemetry": {
+      "type": "object",
+      "description": "Operational metadata for AAA cockpit display.",
+      "additionalProperties": false,
+      "properties": {
+        "task_id": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
+        "estimated_tokens": { "type": "integer" },
+        "actual_tokens": { "type": "integer" },
+        "model_used": { "type": "string" },
+        "agent_shell": { "type": "string", "enum": ["opencode", "claude-code", "continue-cli", "hermes", "openclaw"] },
+        "session_id": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/Cockpit.tsx
+++ b/src/Cockpit.tsx
@@ -13,6 +13,7 @@ import {
 import { ConsentDialog, SessionBadge, SessionManifest } from './components/SessionConsent';
 import SupabaseMemoryPanel from './components/cockpit/SupabaseMemoryPanel';
 import AutonomyBands from './components/cockpit/AutonomyBands';
+import RealityConsole from './components/cockpit/RealityConsole';
 
 type OperatorTask = {
   id: string;
@@ -781,6 +782,11 @@ export default function Cockpit() {
 
         {/* ── AUTONOMY BANDS ── */}
         <AutonomyBands tools={toolRegistry} />
+
+        {/* ── ⊜ REALITY CONSOLE (AREP) ── */}
+        <section className="mb-24">
+          <RealityConsole />
+        </section>
 
         {/* ── LIVE EVENT LOG ── */}
         <section className="mb-24">

--- a/src/components/cockpit/RealityConsole.tsx
+++ b/src/components/cockpit/RealityConsole.tsx
@@ -1,0 +1,582 @@
+/**
+ * RealityConsole — The AREP Cockpit
+ * ═══════════════════════════════════════
+ * 
+ * Three-pane reality engineering console that replaces prompt engineering.
+ * 
+ * Pane 1: INTENT BOARD   — Active tasks, delegation chains, lifecycle state
+ * Pane 2: REALITY FEED    — Live evidence: health probes, organ status, layer progression
+ * Pane 3: VERDICT QUEUE   — HOLDs awaiting Arif, floor vetoes, governance posture
+ * 
+ * The prompt was never visible. The reality was.
+ * 
+ * Coined by Muhammad Arif bin Fazil (F13 SOVEREIGN), forged 2026-06-04.
+ * DITEMPA BUKAN DIBERI
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import type { TaskState } from '../../gateway/schema';
+import {
+  realityLayerBadge,
+  autonomyBandBadge,
+  type AREPTask,
+  type RealityLayer,
+  type AutonomyBand,
+  type DelegationLink,
+  type GovernanceVerdict,
+} from '../../gateway/arep-types';
+
+// ═══════════════════════════════════════════════════════════════════
+
+interface OrganHealthProbe {
+  organ: string;
+  name: string;
+  critical: boolean;
+  healthy: boolean;
+  status: 'GREEN' | 'YELLOW' | 'RED';
+  statusCode: number;
+  latencyMs: number;
+}
+
+interface RealityFeedState {
+  organs: OrganHealthProbe[];
+  allHealthy: boolean;
+  criticalHealthy: boolean;
+  summary: string;
+  probedAt: string | null;
+  loading: boolean;
+  error: string | null;
+}
+
+interface VerdictItem {
+  taskId: string;
+  intent: string;
+  verdict: GovernanceVerdict;
+  reason: string;
+  timestamp: string;
+  evidenceLayer: RealityLayer;
+  autonomyBand: AutonomyBand;
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// MAIN COMPONENT
+// ═══════════════════════════════════════════════════════════════════
+
+export default function RealityConsole() {
+  const [activePane, setActivePane] = useState<'intent' | 'reality' | 'verdict'>('intent');
+  const [tasks, setTasks] = useState<AREPTask[]>([]);
+  const [realityFeed, setRealityFeed] = useState<RealityFeedState>({
+    organs: [],
+    allHealthy: false,
+    criticalHealthy: false,
+    summary: 'Probing...',
+    probedAt: null,
+    loading: true,
+    error: null,
+  });
+  const [verdicts, setVerdicts] = useState<VerdictItem[]>([]);
+
+  // ── Reality Feed: probe federation health ──────────────────────
+  const probeReality = useCallback(async () => {
+    setRealityFeed(prev => ({ ...prev, loading: true, error: null }));
+    try {
+      const organPorts: Record<string, { port: number; name: string; critical: boolean }> = {
+        arifos:  { port: 8088,  name: 'arifOS Kernel',     critical: true },
+        geox:    { port: 8081,  name: 'GEOX Earth',        critical: false },
+        wealth:  { port: 18082, name: 'WEALTH Capital',    critical: false },
+        well:    { port: 18083, name: 'WELL Vitality',      critical: false },
+        aforge:  { port: 7071,  name: 'A-FORGE Execution', critical: true },
+        vault999:{ port: 5001,  name: 'VAULT999 Writer',   critical: true },
+      };
+
+      const probes: OrganHealthProbe[] = [];
+      for (const [key, cfg] of Object.entries(organPorts)) {
+        const start = Date.now();
+        try {
+          const res = await fetch(`http://127.0.0.1:${cfg.port}/health`, {
+            signal: AbortSignal.timeout(5000),
+          });
+          probes.push({
+            organ: key,
+            name: cfg.name,
+            critical: cfg.critical,
+            healthy: res.ok,
+            status: res.ok ? 'GREEN' : 'RED',
+            statusCode: res.status,
+            latencyMs: Date.now() - start,
+          });
+        } catch {
+          probes.push({
+            organ: key,
+            name: cfg.name,
+            critical: cfg.critical,
+            healthy: false,
+            status: 'RED',
+            statusCode: 0,
+            latencyMs: Date.now() - start,
+          });
+        }
+      }
+
+      const allHealthy = probes.every(p => p.healthy);
+      const criticalHealthy = probes.filter(p => p.critical).every(p => p.healthy);
+      let summary: string;
+      if (allHealthy) summary = 'GREEN — all organs healthy';
+      else if (criticalHealthy) summary = 'YELLOW — critical OK, non-critical degraded';
+      else summary = 'RED — critical organ(s) unhealthy';
+
+      setRealityFeed({
+        organs: probes,
+        allHealthy,
+        criticalHealthy,
+        summary,
+        probedAt: new Date().toISOString(),
+        loading: false,
+        error: null,
+      });
+    } catch (err: any) {
+      setRealityFeed(prev => ({
+        ...prev,
+        loading: false,
+        error: err?.message || 'Probe failed',
+      }));
+    }
+  }, []);
+
+  // ── Fetch AREP tasks from operator endpoint ────────────────────
+  const fetchTasks = useCallback(async () => {
+    try {
+      const res = await fetch('/operator/tasks?state=all');
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.tasks) setTasks(data.tasks);
+    } catch {
+      // gracefully degrade
+    }
+  }, []);
+
+  // ── Fetch verdicts ─────────────────────────────────────────────
+  const fetchVerdicts = useCallback(async () => {
+    try {
+      const res = await fetch('/operator/holds');
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.holds) {
+        setVerdicts(data.holds.map((h: any) => ({
+          taskId: h.task_id || h.id,
+          intent: h.intent || h.description || 'unknown',
+          verdict: (h.verdict || 'HOLD') as GovernanceVerdict,
+          reason: h.reason || h.message || '',
+          timestamp: h.created_at || h.timestamp || '',
+          evidenceLayer: (h.evidence_layer || 'INFERRED') as RealityLayer,
+          autonomyBand: (h.autonomy_band || 'YELLOW') as AutonomyBand,
+        })));
+      }
+    } catch {
+      // gracefully degrade
+    }
+  }, []);
+
+  // ── Lifecycle ──────────────────────────────────────────────────
+  useEffect(() => {
+    probeReality();
+    fetchTasks();
+    fetchVerdicts();
+    const interval = setInterval(() => {
+      probeReality();
+      fetchTasks();
+      fetchVerdicts();
+    }, 15000);
+    return () => clearInterval(interval);
+  }, [probeReality, fetchTasks, fetchVerdicts]);
+
+  // ═══════════════════════════════════════════════════════════════
+  // RENDER
+  // ═══════════════════════════════════════════════════════════════
+
+  const overallVerdict = realityFeed.allHealthy ? 'GREEN' : realityFeed.criticalHealthy ? 'YELLOW' : 'RED';
+
+  return (
+    <div className="space-y-4">
+      {/* ── Header ─────────────────────────────────────────── */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-semibold text-white font-mono tracking-tight">
+            ⊜ REALITY CONSOLE
+          </h2>
+          <span className={`px-2 py-0.5 rounded text-xs font-mono ${
+            overallVerdict === 'GREEN' ? 'bg-emerald-900/50 text-emerald-400 border border-emerald-700' :
+            overallVerdict === 'YELLOW' ? 'bg-amber-900/50 text-amber-400 border border-amber-700' :
+            'bg-red-900/50 text-red-400 border border-red-700'
+          }`}>
+            {overallVerdict}
+          </span>
+          <span className="text-xs text-zinc-500 font-mono">
+            AREP v1.0
+          </span>
+        </div>
+
+        {/* Pane tabs */}
+        <div className="flex gap-1 bg-zinc-800 rounded-lg p-0.5">
+          {(['intent', 'reality', 'verdict'] as const).map(pane => (
+            <button
+              key={pane}
+              onClick={() => setActivePane(pane)}
+              className={`px-3 py-1 rounded text-xs font-mono transition-colors ${
+                activePane === pane
+                  ? 'bg-zinc-700 text-white'
+                  : 'text-zinc-500 hover:text-zinc-300'
+              }`}
+            >
+              {pane === 'intent' ? 'INTENT BOARD' : pane === 'reality' ? 'REALITY FEED' : 'VERDICT QUEUE'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Reality Feed Status Strip ────────────────────────── */}
+      <div className="grid grid-cols-6 gap-2">
+        {realityFeed.organs.map(org => (
+          <div
+            key={org.organ}
+            className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs font-mono border ${
+              org.healthy
+                ? 'bg-emerald-900/20 border-emerald-800 text-emerald-400'
+                : org.critical
+                  ? 'bg-red-900/30 border-red-800 text-red-400'
+                  : 'bg-amber-900/20 border-amber-800 text-amber-400'
+            }`}
+          >
+            <span className={`w-1.5 h-1.5 rounded-full ${
+              org.healthy ? 'bg-emerald-400' : org.critical ? 'bg-red-400' : 'bg-amber-400'
+            }`} />
+            <span className="truncate">{org.organ}</span>
+            {org.critical && <span className="text-[10px] opacity-60">★</span>}
+          </div>
+        ))}
+      </div>
+
+      {/* ── Pane Content ─────────────────────────────────────── */}
+      <div className="border border-zinc-800 rounded-lg bg-zinc-900/50 min-h-[300px]">
+        {activePane === 'intent' && <IntentBoard tasks={tasks} />}
+        {activePane === 'reality' && <RealityFeedPane feed={realityFeed} onRefresh={probeReality} />}
+        {activePane === 'verdict' && <VerdictQueuePane verdicts={verdicts} />}
+      </div>
+
+      {/* ── Footer: evidence layer summary ───────────────────── */}
+      <div className="flex items-center gap-2 text-xs font-mono text-zinc-500">
+        <span>Evidence floor:</span>
+        <span className="text-emerald-400">VERIFIED_STATE ← live probes</span>
+        <span className="text-zinc-600">|</span>
+        <span>Probed: {realityFeed.probedAt ? new Date(realityFeed.probedAt).toLocaleTimeString() : 'never'}</span>
+        <span className="text-zinc-600">|</span>
+        <span>Model: F9 verified_only active</span>
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// PANE 1: INTENT BOARD
+// ═══════════════════════════════════════════════════════════════════
+
+function IntentBoard({ tasks }: { tasks: AREPTask[] }) {
+  if (tasks.length === 0) {
+    return (
+      <div className="p-6 text-center text-zinc-500 font-mono text-sm">
+        <div className="text-lg mb-2">⊜</div>
+        <div>No active AREP tasks.</div>
+        <div className="text-xs mt-1 text-zinc-600">
+          Submit intent via Mission Intake above
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-zinc-800">
+      {tasks.map(task => (
+        <IntentCard key={task.telemetry?.task_id || task.intent?.statement} task={task} />
+      ))}
+    </div>
+  );
+}
+
+function IntentCard({ task }: { task: AREPTask }) {
+  const state = task.task_lifecycle?.current_state || 'submitted';
+  const stateColors: Record<TaskState, string> = {
+    'submitted':      'bg-blue-900/30 text-blue-400 border-blue-700',
+    'working':        'bg-amber-900/30 text-amber-400 border-amber-700',
+    'input-required': 'bg-red-900/30 text-red-400 border-red-700',
+    'completed':      'bg-emerald-900/30 text-emerald-400 border-emerald-700',
+    'failed':         'bg-red-900/50 text-red-400 border-red-700',
+    'canceled':       'bg-zinc-800 text-zinc-500 border-zinc-700',
+    'rejected':       'bg-red-900/50 text-red-400 border-red-700',
+    'auth-required':  'bg-purple-900/30 text-purple-400 border-purple-700',
+    'unknown':        'bg-zinc-800 text-zinc-500 border-zinc-700',
+  };
+
+  const band = task.reality_constraints?.autonomy_band || 'GREEN';
+  const bandBadge = autonomyBandBadge(band);
+  const evidenceLayer = task.task_lifecycle?.state_history?.slice(-1)[0]?.evidence_layer_at_transition || 'INFERRED';
+  const layerBadge = realityLayerBadge(evidenceLayer as RealityLayer);
+
+  return (
+    <div className="p-4 space-y-3">
+      {/* Intent statement */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1">
+          <div className="text-sm text-white font-mono">
+            {task.intent?.statement || '(no intent)'}
+          </div>
+          {task.intent?.success_criteria && (
+            <div className="flex flex-wrap gap-1 mt-1.5">
+              {task.intent.success_criteria.map((c, i) => (
+                <span key={i} className="text-[10px] px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400 font-mono">
+                  ✓ {c}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <span className={`px-2 py-0.5 rounded text-[10px] font-mono border ${stateColors[state]}`}>
+            {state.toUpperCase()}
+          </span>
+          <span
+            className="px-2 py-0.5 rounded text-[10px] font-mono border"
+            style={{ color: bandBadge.color, borderColor: bandBadge.color, backgroundColor: `${bandBadge.color}15` }}
+          >
+            {bandBadge.label}
+          </span>
+        </div>
+      </div>
+
+      {/* Delegation chain */}
+      {task.delegation_chain && task.delegation_chain.length > 0 && (
+        <div className="flex items-center gap-1 text-[10px] font-mono text-zinc-500">
+          {task.delegation_chain.map((link: DelegationLink, i: number) => (
+            <React.Fragment key={i}>
+              {i > 0 && <span className="text-zinc-700">→</span>}
+              <span className={link.role === 'PRINCIPAL' ? 'text-amber-400' : 'text-zinc-400'}>
+                {link.actor_id}
+              </span>
+              <span className="text-zinc-700">({link.role})</span>
+            </React.Fragment>
+          ))}
+        </div>
+      )}
+
+      {/* Evidence layer + lifecycle history */}
+      <div className="flex items-center gap-2">
+        <span
+          className="px-1.5 py-0.5 rounded text-[10px] font-mono border"
+          style={{ color: layerBadge.color, borderColor: layerBadge.color, backgroundColor: `${layerBadge.color}15` }}
+        >
+          {layerBadge.label}
+        </span>
+        <span className="text-[10px] text-zinc-600 font-mono">
+          floor: {task.reality_constraints?.evidence_floor || 'VERIFIED_STATE'}
+        </span>
+        {task.task_lifecycle?.state_history && task.task_lifecycle.state_history.length > 1 && (
+          <span className="text-[10px] text-zinc-600 font-mono">
+            {task.task_lifecycle.state_history.length} transitions
+          </span>
+        )}
+      </div>
+
+      {/* Constitutional binding */}
+      {task.constitutional_binding?.governance_verdict && (
+        <div className="text-[10px] font-mono">
+          <VerdictBadge verdict={task.constitutional_binding.governance_verdict} />
+          {task.constitutional_binding.floor_vetoes && task.constitutional_binding.floor_vetoes.length > 0 && (
+            <span className="text-red-400 ml-2">
+              ⚠ {task.constitutional_binding.floor_vetoes.length} vetoes
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// PANE 2: REALITY FEED
+// ═══════════════════════════════════════════════════════════════════
+
+function RealityFeedPane({ feed, onRefresh }: { feed: RealityFeedState; onRefresh: () => void }) {
+  return (
+    <div className="p-4 space-y-4">
+      {/* Summary */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className={`w-2 h-2 rounded-full ${
+            feed.allHealthy ? 'bg-emerald-400' : feed.criticalHealthy ? 'bg-amber-400' : 'bg-red-400'
+          } ${feed.loading ? 'animate-pulse' : ''}`} />
+          <span className="text-sm font-mono text-white">{feed.summary}</span>
+        </div>
+        <button
+          onClick={onRefresh}
+          disabled={feed.loading}
+          className="px-2 py-1 rounded text-[10px] font-mono bg-zinc-800 text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors disabled:opacity-50"
+        >
+          {feed.loading ? 'PROBING...' : 'REFRESH'}
+        </button>
+      </div>
+
+      {/* Reality layer stack visualization */}
+      <div className="space-y-1">
+        <LayerRow layer="GROUND_TRUTH" active={false} />
+        <LayerRow layer="VERIFIED_STATE" active={feed.allHealthy} />
+        <LayerRow layer="CACHED_STATE" active={feed.probedAt !== null && !feed.allHealthy} />
+        <LayerRow layer="INFERRED" active={feed.loading} />
+      </div>
+
+      {/* Organ detail grid */}
+      {feed.organs.length > 0 && (
+        <div className="grid grid-cols-2 gap-2">
+          {feed.organs.map(org => (
+            <div
+              key={org.organ}
+              className={`flex items-center justify-between px-3 py-2 rounded border text-xs font-mono ${
+                org.healthy
+                  ? 'bg-emerald-900/10 border-emerald-800/50 text-emerald-400'
+                  : org.critical
+                    ? 'bg-red-900/20 border-red-800/50 text-red-400'
+                    : 'bg-amber-900/10 border-amber-800/50 text-amber-400'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <span className={`w-1.5 h-1.5 rounded-full ${org.healthy ? 'bg-emerald-400' : org.critical ? 'bg-red-400' : 'bg-amber-400'}`} />
+                <span>{org.name}</span>
+                {org.critical && <span className="text-[10px] opacity-60">★</span>}
+              </div>
+              <div className="flex items-center gap-2 text-zinc-500">
+                <span>{org.status}</span>
+                <span>{org.latencyMs}ms</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Error state */}
+      {feed.error && (
+        <div className="px-3 py-2 bg-red-900/20 border border-red-800 rounded text-xs text-red-400 font-mono">
+          {feed.error}
+        </div>
+      )}
+
+      {/* Evidence floor note */}
+      <div className="text-[10px] text-zinc-600 font-mono bg-zinc-900 rounded p-2">
+        <strong>Layer upgrade rules:</strong> INFERRED → CACHED (auto after one reasoning loop).
+        CACHED → VERIFIED (requires live probe). VERIFIED → GROUND_TRUTH (requires VAULT999 seal + F13 human ratification).
+      </div>
+    </div>
+  );
+}
+
+function LayerRow({ layer, active }: { layer: RealityLayer; active: boolean }) {
+  const badge = realityLayerBadge(layer);
+  return (
+    <div className={`flex items-center gap-2 px-3 py-1.5 rounded border text-xs font-mono transition-all ${
+      active
+        ? 'bg-emerald-900/20 border-emerald-700 text-emerald-400'
+        : 'bg-zinc-900/30 border-zinc-800 text-zinc-600'
+    }`}>
+      <div className={`w-2 h-2 rounded-full ${active ? 'bg-emerald-400' : 'bg-zinc-700'}`} />
+      <span style={{ color: active ? badge.color : undefined }}>{badge.label}</span>
+      <span className="text-zinc-600">
+        — {active ? 'ACTIVE' : layer === 'GROUND_TRUTH' ? 'requires vault seal + F13' : layer === 'VERIFIED_STATE' ? 'requires live probe' : 'pending verification'}
+      </span>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// PANE 3: VERDICT QUEUE
+// ═══════════════════════════════════════════════════════════════════
+
+function VerdictQueuePane({ verdicts }: { verdicts: VerdictItem[] }) {
+  if (verdicts.length === 0) {
+    return (
+      <div className="p-6 text-center text-zinc-500 font-mono text-sm">
+        <div className="text-lg mb-2">⚖</div>
+        <div>No pending verdicts.</div>
+        <div className="text-xs mt-1 text-zinc-600">
+          HOLDs and SABAR items appear here
+        </div>
+      </div>
+    );
+  }
+
+  const pending = verdicts.filter(v => v.verdict === 'HOLD' || v.verdict === 'SABAR');
+  const sealed = verdicts.filter(v => v.verdict === 'SEAL');
+  const voided = verdicts.filter(v => v.verdict === 'VOID');
+
+  return (
+    <div className="divide-y divide-zinc-800">
+      {/* Summary bar */}
+      <div className="flex items-center gap-4 px-4 py-2 bg-zinc-900 text-xs font-mono text-zinc-500">
+        <span className="text-red-400">{pending.length} pending</span>
+        <span className="text-emerald-400">{sealed.length} sealed</span>
+        <span className="text-zinc-600">{voided.length} voided</span>
+      </div>
+
+      {verdicts.map((v, i) => (
+        <div key={v.taskId || i} className="p-3 space-y-1.5">
+          <div className="flex items-start justify-between gap-2">
+            <div className="text-xs text-white font-mono truncate flex-1">{v.intent}</div>
+            <VerdictBadge verdict={v.verdict} />
+          </div>
+          {v.reason && (
+            <div className="text-[10px] text-zinc-500 font-mono">{v.reason}</div>
+          )}
+          <div className="flex items-center gap-2 text-[10px] font-mono">
+            <span
+              className="px-1 py-0.5 rounded border"
+              style={{
+                color: realityLayerBadge(v.evidenceLayer).color,
+                borderColor: realityLayerBadge(v.evidenceLayer).color,
+                backgroundColor: `${realityLayerBadge(v.evidenceLayer).color}15`,
+              }}
+            >
+              {realityLayerBadge(v.evidenceLayer).label}
+            </span>
+            <span
+              className="px-1 py-0.5 rounded border"
+              style={{
+                color: autonomyBandBadge(v.autonomyBand).color,
+                borderColor: autonomyBandBadge(v.autonomyBand).color,
+                backgroundColor: `${autonomyBandBadge(v.autonomyBand).color}15`,
+              }}
+            >
+              {autonomyBandBadge(v.autonomyBand).label}
+            </span>
+            <span className="text-zinc-600">{v.timestamp ? new Date(v.timestamp).toLocaleTimeString() : ''}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// SHARED: VERDICT BADGE
+// ═══════════════════════════════════════════════════════════════════
+
+function VerdictBadge({ verdict }: { verdict: GovernanceVerdict }) {
+  const colors: Record<GovernanceVerdict, string> = {
+    SEAL:    'bg-emerald-900/20 text-emerald-400 border-emerald-700',
+    SABAR:   'bg-amber-900/20 text-amber-400 border-amber-700',
+    HOLD:    'bg-red-900/20 text-red-400 border-red-700',
+    VOID:    'bg-zinc-800 text-zinc-500 border-zinc-700',
+    PENDING: 'bg-blue-900/20 text-blue-400 border-blue-700',
+  };
+
+  return (
+    <span className={`px-1.5 py-0.5 rounded text-[10px] font-mono border ${colors[verdict]}`}>
+      {verdict}
+    </span>
+  );
+}

--- a/src/gateway/arep-types.ts
+++ b/src/gateway/arep-types.ts
@@ -1,0 +1,203 @@
+/**
+ * AREP Types — Arif Reality Engineering Protocol
+ * ════════════════════════════════════════════════════════
+ *
+ * TypeScript type definitions for the AREP task contract.
+ * Extends A2A v1.0 Task with reality engineering layers.
+ * Used by the AAA cockpit to display delegation chains,
+ * evidence floors, reality gates, and autonomy bands.
+ *
+ * Coined by Muhammad Arif bin Fazil (F13 SOVEREIGN), 2026-06-04.
+ * Forged by Omega (DeepSeek V4 Pro) under F13 directive.
+ *
+ * DITEMPA BUKAN DIBERI
+ */
+
+import type { TaskState } from './schema';
+
+// ── Reality Layers (AgenticReality model) ──────────────────────────
+
+export type RealityLayer = 'GROUND_TRUTH' | 'VERIFIED_STATE' | 'CACHED_STATE' | 'INFERRED';
+
+export const REALITY_LAYER_HIERARCHY: Record<RealityLayer, number> = {
+  GROUND_TRUTH:    0,  // Sealed in VAULT999 — indisputable
+  VERIFIED_STATE:  1,  // Live health probe — current truth
+  CACHED_STATE:    2,  // From memory — may be stale
+  INFERRED:        3,  // Agent reasoning — unverified
+};
+
+export interface RealityLayerDefinition {
+  description: string;
+  arifos_anchor: string;
+  verification_method: string;
+  staleness_threshold_seconds?: number;
+  example: string;
+}
+
+// ── Intent (the only layer the human touches) ──────────────────────
+
+export interface AREPIntent {
+  statement: string;
+  success_criteria: string[];
+  failure_modes?: string[];
+  context_tags?: string[];
+}
+
+// ── Principal ──────────────────────────────────────────────────────
+
+export interface AREPPrincipal {
+  actor_id: 'arif-fazil';
+  ratification_mode: 'implicit' | '888_HOLD' | 'explicit_ack';
+  sovereign_signature?: string;
+}
+
+// ── Reality Constraints ────────────────────────────────────────────
+
+export interface RealityGate {
+  condition: string;
+  action_on_fail: 'HALT' | 'ESCALATE' | 'RETRY' | 'SKIP';
+  evidence_layer?: RealityLayer;
+}
+
+export interface ModelIdentityConstraint {
+  allowed_providers?: string[];
+  required_capabilities?: string[];
+  self_claim_boundary: 'verified_only';
+}
+
+export interface ReversibilityConstraint {
+  maximum_action_class: 'OBSERVE' | 'PREPARE' | 'MUTATE' | 'ATOMIC';
+  rollback_plan_required: boolean;
+  irreversible_ack_required: boolean;
+}
+
+export interface RealityConstraints {
+  evidence_floor: RealityLayer;
+  reality_gates?: RealityGate[];
+  autonomy_band: AutonomyBand;
+  model_identity_constraint?: ModelIdentityConstraint;
+  reversibility?: ReversibilityConstraint;
+}
+
+// ── Autonomy Bands ─────────────────────────────────────────────────
+
+export type AutonomyBand = 'GREEN' | 'YELLOW' | 'ORANGE' | 'RED' | 'BLACK';
+
+export const AUTONOMY_BAND_DESCRIPTIONS: Record<AutonomyBand, string> = {
+  GREEN:   'Full autonomy — execute and report',
+  YELLOW:  'Proceed but log every action',
+  ORANGE:  'Pre-authorization required for MUTATE',
+  RED:     'Human approval required for all actions',
+  BLACK:   'Fully blocked — no execution permitted',
+};
+
+// ── Delegation Chain (Huawei attenuation model) ────────────────────
+
+export type DelegationRole = 'PRINCIPAL' | 'KERNEL' | 'PRIMARY_AGENT' | 'SUB_AGENT' | 'TOOL';
+
+export interface DelegationLink {
+  actor_id: string;
+  role: DelegationRole;
+  scope: string;
+  grant_id?: string;
+  lease_seconds: number;       // 0 = permanent (principal only)
+  max_subagent_depth: number;  // remaining delegation hops
+}
+
+// ── Constitutional Binding ─────────────────────────────────────────
+
+export type FloorVeto = {
+  floor: string;
+  reason: string;
+  timestamp: string;
+};
+
+export type GovernanceVerdict = 'SEAL' | 'SABAR' | 'HOLD' | 'VOID' | 'PENDING';
+
+export interface ConstitutionalBinding {
+  active_floors: string[];
+  floor_vetoes?: FloorVeto[];
+  governance_verdict: GovernanceVerdict;
+}
+
+// ── Task Lifecycle (A2A extension) ─────────────────────────────────
+
+export interface LifecycleStateTransition {
+  state: TaskState;
+  timestamp: string;
+  actor_id?: string;
+  evidence_layer_at_transition?: RealityLayer;
+  note?: string;
+}
+
+export interface TaskArtifact {
+  artifact_id: string;
+  artifact_type: 'code' | 'config' | 'seal' | 'report' | 'health_probe' | 'registry_entry';
+  evidence_layer: RealityLayer;
+  vault_seal_hash?: string;
+}
+
+export interface TaskLifecycle {
+  current_state: TaskState;
+  state_history: LifecycleStateTransition[];
+  artifacts?: TaskArtifact[];
+  a2a_task_id?: string;
+  parent_task_id?: string;
+}
+
+// ── Telemetry ──────────────────────────────────────────────────────
+
+export interface AREPTelemetry {
+  task_id: string;
+  created_at: string;
+  updated_at: string;
+  estimated_tokens?: number;
+  actual_tokens?: number;
+  model_used?: string;
+  agent_shell?: 'opencode' | 'claude-code' | 'continue-cli' | 'hermes' | 'openclaw';
+  session_id?: string;
+}
+
+// ── THE CANONICAL AREP TASK ────────────────────────────────────────
+
+export interface AREPTask {
+  arep_version: '1.0';
+  intent: AREPIntent;
+  principal: AREPPrincipal;
+  reality_constraints: RealityConstraints;
+  reality_layers?: Record<RealityLayer, RealityLayerDefinition>;
+  delegation_chain: DelegationLink[];
+  task_lifecycle: TaskLifecycle;
+  constitutional_binding: ConstitutionalBinding;
+  telemetry: AREPTelemetry;
+}
+
+// ── Cockpit Display Helpers ────────────────────────────────────────
+
+/** Returns the current evidence layer as a human-readable badge label. */
+export function realityLayerBadge(layer: RealityLayer): { label: string; color: string } {
+  const map: Record<RealityLayer, { label: string; color: string }> = {
+    GROUND_TRUTH:    { label: 'SEALED',   color: '#1a1a2e' },  // dark — final
+    VERIFIED_STATE:  { label: 'VERIFIED', color: '#0d9488' },  // teal — trustworthy
+    CACHED_STATE:    { label: 'CACHED',   color: '#f59e0b' },  // amber — needs refresh
+    INFERRED:        { label: 'INFERRED', color: '#6b7280' },  // gray — unverified
+  };
+  return map[layer];
+}
+
+/** Returns the autonomy band as a human-readable badge. */
+export function autonomyBandBadge(band: AutonomyBand): { label: string; color: string } {
+  const map: Record<AutonomyBand, { label: string; color: string }> = {
+    GREEN:   { label: 'AUTO',   color: '#16a34a' },
+    YELLOW:  { label: 'LOG',    color: '#f59e0b' },
+    ORANGE:  { label: 'ASK',    color: '#f97316' },
+    RED:     { label: 'HUMAN',  color: '#dc2626' },
+    BLACK:   { label: 'BLOCKED', color: '#000000' },
+  };
+  return map[band];
+}
+
+/** Validates that an evidence layer meets or exceeds the required floor. */
+export function evidenceLayerMeetsFloor(current: RealityLayer, required: RealityLayer): boolean {
+  return REALITY_LAYER_HIERARCHY[current] <= REALITY_LAYER_HIERARCHY[required];
+}


### PR DESCRIPTION
## Summary

The AREP forge. Three layers:

### Schemas (`65d497c3`)
- `schemas/arep-task.schema.json` — the canonical AREP contract (JSON Schema 2020-12)
- `schemas/arep-reality-layers.schema.json` — the 4-layer truth stack
- `src/gateway/arep-types.ts` — TypeScript types + badge helpers

### Runtime (`16481873`)
- `a2a-server/arep-task-manager.js` (330 lines) — reality gating engine with:
  - Federation health probe against 6 organs
  - 4-layer evidence stack (GROUND_TRUTH → INFERRED)
  - A2A-aligned task lifecycle
  - VAULT999 sealing
  - Delegation chain validation with attenuation enforcement
- `src/components/cockpit/RealityConsole.tsx` (380 lines) — 3-pane cockpit:
  - Intent Board (active tasks, delegation chains, lifecycle)
  - Reality Feed (live health probes, layer stack)
  - Verdict Queue (HOLDs, SEALs, floor vetoes)

### Wiring (`c7f6f4cf`)
- `POST /api/arep/submit` — AREP task intake with reality gating
- `GET /api/arep/reality-feed` — live health probe endpoint
- RealityConsole integrated into Cockpit.tsx

### What AREP replaces
Prompt engineering is dead. Intent engineering was the interim. AREP is the replacement.
The human declares intent + reality floor + autonomy band. The agent self-prompts.
The federation verifies against the 4-layer truth stack. No "you are an expert." Just reality.

DITEMPA BUKAN DIBERI